### PR TITLE
Fix teleport for tech 3 Aeon bot

### DIFF
--- a/units/EAL0301/EAL0301_Script.lua
+++ b/units/EAL0301/EAL0301_Script.lua
@@ -5,7 +5,7 @@
 --**
 --**  Summary  :  Aeon Siege Assault Bot Script
 --**
---**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--**  Copyright Â© 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
 local AWalkingLandUnit = import('/lua/aeonunits.lua').AWalkingLandUnit
@@ -17,6 +17,13 @@ EAL0301 = Class(AWalkingLandUnit) {
     Weapons = {
         FrontTurret01 = Class(ADFReactonCannon) {}
     },
+
+    OnCreate = function(self)
+        AWalkingLandUnit.OnCreate(self)
+
+        -- allow this unit to teleport
+        self:AddCommandCap('RULEUCC_Teleport')
+    end,
 
     OnStopBeingBuilt = function(self,builder,layer)
         AWalkingLandUnit.OnStopBeingBuilt(self,builder,layer)


### PR DESCRIPTION
Adds the command cap manually. The engine version to check the command caps has been bugged since forever. We introduced the check to guarantee the player has the command capabilities to prevent cheating.

Bug fix initiated from the FAF forums, see also:

- https://forum.faforever.com/topic/353/blackopsfaf-unleashed-only-for-faf-v20/79